### PR TITLE
Feature: Moves 'Backup Sheet' creation to 'Init Configuration' (#21)

### DIFF
--- a/modules/spreadsheet/configuration/configurationSpreadsheet.js
+++ b/modules/spreadsheet/configuration/configurationSpreadsheet.js
@@ -69,4 +69,21 @@ function createConfigSheet () {
   sheetConfig.setColumnWidth(3, 750);
 
   showToast(`${messageStateEmoji().DONE} Hoja de Configuración`, messageBody);
+
+  //~ Se crea la "Hoja de Respaldo" en caso de no existir ~//
+  const dataConfigSheet = getDataConfigSheet();
+  createBackupSheet(dataConfigSheet);
+}
+
+function createBackupSheet(dataConfigSheet) {
+  let sheetBackup = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(dataConfigSheet.SHEET_BACKUP);
+
+  if (sheetBackup === null) {
+    sheetBackup = SpreadsheetApp.getActiveSpreadsheet().insertSheet();
+    sheetBackup.setName(dataConfigSheet.SHEET_BACKUP);
+
+    showToast(`${messageStateEmoji().DONE} Hoja de Respaldo`, `Se creó la "Hoja de Respaldo" con los datos de la "Hoja de Respuestas".`);
+  } else {
+    showToast(`${messageStateEmoji().DONE} Hoja de Respaldo`, `La hoja ya existe, no se realizaron cambios.`);
+  }
 }

--- a/modules/spreadsheet/configuration/configurationSpreadsheet.js
+++ b/modules/spreadsheet/configuration/configurationSpreadsheet.js
@@ -46,12 +46,12 @@ function createConfigSheet () {
         flagChanged = true;
       }
 
-      if (configObject[key].value !== '' && sheetConfig.getRange(row, 2).getValue() !== configObject[key].value) {
+      if (sheetConfig.getRange(row, 2).getValue() === '') {
         sheetConfig.getRange(row, 2).setValue(configObject[key].value);
         flagChanged = true;
       }
 
-      if (configObject[key].description !== '' && sheetConfig.getRange(row, 3).getValue() !== configObject[key].description) {
+      if (sheetConfig.getRange(row, 3).getValue() === '') {
         sheetConfig.getRange(row, 3).setValue(configObject[key].description);
         flagChanged = true;
       }
@@ -60,7 +60,7 @@ function createConfigSheet () {
     }
 
     if (flagChanged) {
-      messageBody = 'Se actualizó la hoja con los valores por defecto.';
+      messageBody = 'Existían valores por defecto en blanco, por lo que se actualizó la hoja con los valores por defecto.';
     }
   }
 

--- a/modules/spreadsheet/copy/copier.js
+++ b/modules/spreadsheet/copy/copier.js
@@ -9,9 +9,6 @@ function copyAllRows() {
     'Se está copiando las filas de la "Hoja de Respuestas" a la "Hoja de Respaldo".'
   );
 
-  //~ Se crea la "Hoja de Respaldo" en caso de no existir ~//
-  createBackupSheet(dataConfigSheet);
-
   //~ Se copian los valores de la "Hoja de Respuestas" a la "Hoja de Respaldo" ~//
   const sheetResponses = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(dataConfigSheet.SHEET_RESPONSES);
   const sheetBackup = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(dataConfigSheet.SHEET_BACKUP);
@@ -162,17 +159,4 @@ function copySpecificRow() {
     `${messageStateEmoji().DONE} Copiado Finalizado`,
     `Se copió la fila ${currentRow} de la "Hoja de Respuestas" a la "Hoja de Respaldo".`
   );
-}
-
-function createBackupSheet(dataConfigSheet) {
-  let sheetBackup = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(dataConfigSheet.SHEET_BACKUP);
-
-  if (sheetBackup === null) {
-    let messageHeader = `${messageStateEmoji().WARNING} Creando respaldo`;
-    let messageBody = 'Creando el respaldo con los datos de la "Hoja de Respuestas".';
-    sheetBackup = SpreadsheetApp.getActiveSpreadsheet().insertSheet();
-    sheetBackup.setName(dataConfigSheet.SHEET_BACKUP);
-
-    showToast(messageHeader, messageBody);
-  }
 }


### PR DESCRIPTION
### 📋 Resumen

- Se ha movido la creación de la 'Hoja de Respaldo' para que esté dentro de la opción '⚙️ Configuración Inicial'
  - Antes se encontraba dentro de la opción '✏️ Copiado de Filas' ➡️ '✴️ Completa'
- Se actualizó la lógica para rellenar campos por defectos, ahora solo lo hará cuando el campo está vacío

---

### 🧩 Tipo de cambio

- [ ] ✨ Feature (nueva funcionalidad)
- [ ] 🐛 Bugfix (corrección de un bug)
- [ ] 🔥 Hotfix (urgente en producción)
- [X] ♻️ Refactor (mejora interna, sin cambios funcionales)
- [ ] 📝 Docs (documentación solamente)
- [ ] 🚧 Chore (tareas menores, mantenimiento)
- [ ] ✅ Test (nuevos tests o ajustes)

---

### 🔗 Relacionado

- Issue: #21

---
