### PR TITLE
Feature: Adds error message when is missing 'Response Sheet' (#18)

### DIFF
--- a/modules/spreadsheet/configuration/configurationSpreadsheet.js
+++ b/modules/spreadsheet/configuration/configurationSpreadsheet.js
@@ -23,8 +23,7 @@ function createConfigSheet () {
       row++;
     }
 
-    messageBody = `Se creó la 'Hoja de Configuración' con los valores por defecto.`;
-    const messageBodyAlert = messageBody + `
+    messageBody = `Se creó la 'Hoja de Configuración' con los valores por defecto.
     \n⚠️ Recuerde rellenar todos los campos de la hoja. ⚠️
     \n• Los campos importantes son:
     - ID Carpeta A (ID_FOLDER_A: Donde se guardarán los documentos generados de la jornada de la mañana)

--- a/modules/spreadsheet/utilities.js
+++ b/modules/spreadsheet/utilities.js
@@ -41,6 +41,18 @@ function validateConfigSheet(dataConfigSheet) {
     return false;
   }
 
+  if (
+    SpreadsheetApp.getActiveSpreadsheet().getSheetByName(dataConfigSheet.SHEET_RESPONSES) === null
+  ) {
+    showMessage(
+      `${messageStateEmoji().ERROR} Hoja de Respuestas`,
+      `No se encontró la "Hoja de Respuestas"
+      Verifique que el nombre esté correctamente escrito
+      Se ha detenido la ejecución.`
+    );
+    return false;
+  }
+
   return true;
 }
 


### PR DESCRIPTION
### 📋 Resumen

- Se agregó validación para cuando no se encuentra la "Hoja de Respuestas"
- Mejora menor con variable para mensaje de creación de "Hoja de Configuración"

---

### 🧩 Tipo de cambio

- [X] ✨ Feature (nueva funcionalidad)
- [ ] 🐛 Bugfix (corrección de un bug)
- [ ] 🔥 Hotfix (urgente en producción)
- [ ] ♻️ Refactor (mejora interna, sin cambios funcionales)
- [ ] 📝 Docs (documentación solamente)
- [ ] 🚧 Chore (tareas menores, mantenimiento)
- [ ] ✅ Test (nuevos tests o ajustes)

---

### 🔗 Relacionado

- Issue: #18 

---
